### PR TITLE
Improve hexadecimal numeric pattern

### DIFF
--- a/grammars/p8.cson
+++ b/grammars/p8.cson
@@ -27,7 +27,7 @@
         'name': 'meta.function.p8'
       }
       {
-        'match': '(?<![\\d.])\\s0x[a-fA-F\\d]+|\\b\\d+(\\.\\d+)?([eE]-?\\d+)?|\\.\\d+([eE]-?\\d+)?'
+        'match': '(?<![\\d.])0x[a-fA-F\\d]+|\\b\\d+(\\.\\d+)?([eE]-?\\d+)?|\\.\\d+([eE]-?\\d+)?'
         'name': 'constant.numeric.p8'
       }
       {


### PR DESCRIPTION
Removed requirement for a whitespace before 0x* patterns will be recognized, allowing hexadecimal numbers to be highlighted correctly in assignment and function call contexts without whitespace.