### PR TITLE
Functions should be scoped as entity.function

### DIFF
--- a/grammars/p8.cson
+++ b/grammars/p8.cson
@@ -130,7 +130,7 @@
       }
       {
         'match': '\\b([A-Za-z_]\\w*)\\b(?=\\s*(?:[({"\']|\\[\\[))'
-        'name': 'support.function.any-method.p8'
+        'name': 'entity.function.name.p8'
       }
       {
         'match': '(?<=[^.]\\.|:)\\b([A-Za-z_]\\w*)'


### PR DESCRIPTION
This makes [catnipped/pico8-syntax](https://github.com/catnipped/pico8-syntax) style defined functions differently from API functions (as is the case in the PICO-8 editor)